### PR TITLE
Fix application helper bug

### DIFF
--- a/app/templates/helpers/application_helper.rb
+++ b/app/templates/helpers/application_helper.rb
@@ -5,10 +5,10 @@ module ApplicationHelper
         manifest = Rails.configuration.webpack[:asset_manifest][bundle]
         bundle = manifest.instance_of?(Array) ? manifest[0] : manifest
 
-        "assets/#{bundle}"
+        "/assets/#{bundle}"
       else
         #"http://localhost:8080/assets/build/#{bundle}.bundle.js" # Hot module replacement
-        "assets/build/#{bundle}.bundle"
+        "/assets/build/#{bundle}.bundle"
       end
 
     "<script src='#{src}' type='text/javascript'></script>".html_safe


### PR DESCRIPTION
Run into problem when using namespace in `route.rb`, You should use the root path instead.
